### PR TITLE
Temporary fix to docker container not working for RabbitMQ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,5 @@ ADD rabbitmq.config /etc/rabbitmq/rabbitmq.config
 # For RabbitMQ and RabbitMQ Adminm
 EXPOSE 5672 15672
 
+USER rabbitmq
 ENTRYPOINT ["/usr/sbin/rabbitmq-server"]


### PR DESCRIPTION
literally two words added to the Dockerfile. Have a look to see if it behaves as expected.
